### PR TITLE
Enabled deferred decal

### DIFF
--- a/Assets/Raymarching/Shaders/Common/RaymarchingUtility.hlsl
+++ b/Assets/Raymarching/Shaders/Common/RaymarchingUtility.hlsl
@@ -152,7 +152,17 @@ void ToHDRPSurfaceAndBuiltinData(FragInputs input, float3 V, inout PositionInput
     surfaceData.metallic = surface.Metallic;
     input.positionRWS = surface.Position;
     posInput.positionWS = surface.Position;
-    GetBuiltinData(input, V, posInput, surfaceData, 0.0, surface.BentNormal, 0.0, builtinData);
+
+    float alpha = 1.0;
+#if HAVE_DECALS
+    if (_EnableDecals)
+    {
+        DecalSurfaceData decalSurfaceData = GetDecalSurfaceData(posInput, alpha);
+        ApplyDecalToSurfaceData(decalSurfaceData, surfaceData);
+    }
+#endif
+
+    GetBuiltinData(input, V, posInput, surfaceData, alpha, surface.BentNormal, 0.0, builtinData);
     builtinData.emissiveColor = surface.Emissive;
 }
 


### PR DESCRIPTION
- Enabled deferred decal.
- Since it is a deferred pass, I think that 1.0 is good for alpha.
- Since the drawing order of GBuffer and DBuffer is switched, DBuffer of the previous frame is used.
  - https://github.com/kaneta1992/ScriptableRenderPipeline/commit/acabb5b954a1f3c6317f50d1dc8b1f5cee33cab9

![image](https://user-images.githubusercontent.com/11267246/63523252-bfe5f200-c534-11e9-8eeb-47419708cbf0.png)
